### PR TITLE
Sl/aligned heading drive

### DIFF
--- a/robot-production/src/main/java/frc/robot/Constants.java
+++ b/robot-production/src/main/java/frc/robot/Constants.java
@@ -65,7 +65,7 @@ public final class Constants {
     public static final String LOG_PATH = SHARED.LOG_FOLDER + "/SWERVE/";
 
     // TODO: Double check that these PID constants still work
-    public static final double SNAP_TO_kP = 3.7;
+    public static final double SNAP_TO_kP = 3.2;
     public static final double SNAP_TO_kI = 0.0;
     public static final double SNAP_TO_kD = 0.1;
 

--- a/robot-production/src/main/java/frc/robot/RobotContainer.java
+++ b/robot-production/src/main/java/frc/robot/RobotContainer.java
@@ -49,6 +49,7 @@ public class RobotContainer {
   // Driver Controls
   private final Trigger RESET_HEADING = driverController.back();
   // private final Trigger SLOW_MODE = driverController.leftTrigger();
+  private final Trigger ALIGN_HEADING = driverController.y();
   private final Trigger INTAKE_RUN = driverController.rightTrigger();
   private final Trigger INTAKE_REVERSE = driverController.rightBumper();
   private final Trigger INTAKE_EXTEND = driverController.leftBumper();
@@ -126,6 +127,8 @@ public class RobotContainer {
     // SLOW_MODE.onTrue(swerve.runOnce(() -> swerve.setSlowMode(true)))
     // .onFalse(swerve.runOnce(() -> swerve.setSlowMode(false)));
 
+    ALIGN_HEADING.onTrue(swerve.runOnce(() -> swerve.alignedHeading()));
+
     INTAKE_RUN.onTrue(scoring.intake.runIntakeRollersCommand())
         .onFalse(scoring.intake.stopRollerCommand());
     INTAKE_REVERSE.onTrue(scoring.intake.runReversedIntakeRollersCommand())
@@ -151,6 +154,8 @@ public class RobotContainer {
     RESET_TURRET.onTrue(scoring.turret.resetPosCommand());
 
     MANUAL_OVERRIDE.onTrue(scoring.overrideTrackingCommand());
+
+
 
     // SNAP_TO.onTrue(swerve.runOnce(() -> swerve.snapToAngle(new Rotation2d(90))));
   }

--- a/robot-production/src/main/java/frc/robot/subsystems/swerve/Swerve.java
+++ b/robot-production/src/main/java/frc/robot/subsystems/swerve/Swerve.java
@@ -3,10 +3,13 @@
 // the WPILib BSD license file in the root directory of this project.
 package frc.robot.subsystems.swerve;
 
-import frc.robot.Constants.*;
-import frc.robot.Robot;
-import frc.robot.helpers.SmoothingFilter;
-
+import org.littletonrobotics.junction.Logger;
+import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
+import com.ctre.phoenix6.swerve.SwerveRequest;
+import com.pathplanner.lib.auto.AutoBuilder;
+import com.pathplanner.lib.config.PIDConstants;
+import com.pathplanner.lib.config.RobotConfig;
+import com.pathplanner.lib.controllers.PPHolonomicDriveController;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -15,17 +18,9 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
-
-import org.littletonrobotics.junction.Logger;
-
-import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
-import com.ctre.phoenix6.swerve.SwerveRequest;
-import com.ctre.phoenix6.swerve.SwerveDrivetrain.SwerveControlParameters;
-import com.ctre.phoenix6.swerve.SwerveModule;
-import com.pathplanner.lib.auto.AutoBuilder;
-import com.pathplanner.lib.config.PIDConstants;
-import com.pathplanner.lib.config.RobotConfig;
-import com.pathplanner.lib.controllers.PPHolonomicDriveController;
+import frc.robot.Constants.SWERVE;
+import frc.robot.Robot;
+import frc.robot.helpers.SmoothingFilter;
 
 public class Swerve extends SubsystemBase {
 
@@ -173,9 +168,13 @@ public class Swerve extends SubsystemBase {
     public void drive(ChassisSpeeds speeds) {
         Logger.recordOutput(SWERVE.LOG_PATH + "TargetSpeeds", speeds);
 
+        double targetHeadingRadians = Math.atan2(speeds.vyMetersPerSecond, speeds.vxMetersPerSecond);
+        Rotation2d targetHeading = new Rotation2d(targetHeadingRadians);
+        double omega = snapToAngle(targetHeading);
+
         swerve.setControl(fieldCentric.withVelocityX(speeds.vxMetersPerSecond)
                 .withVelocityY(speeds.vyMetersPerSecond)
-                .withRotationalRate(speeds.omegaRadiansPerSecond));
+                .withRotationalRate(omega));
     }
 
     /**

--- a/robot-production/src/main/java/frc/robot/subsystems/swerve/Swerve.java
+++ b/robot-production/src/main/java/frc/robot/subsystems/swerve/Swerve.java
@@ -27,6 +27,7 @@ public class Swerve extends SubsystemBase {
     private PIDController snapToController;
 
     private boolean isSlowMode;
+    private boolean alignedHeading = false;
 
     private SmoothingFilter smoothingFilter;
 
@@ -168,13 +169,20 @@ public class Swerve extends SubsystemBase {
     public void drive(ChassisSpeeds speeds) {
         Logger.recordOutput(SWERVE.LOG_PATH + "TargetSpeeds", speeds);
 
-        double targetHeadingRadians = Math.atan2(speeds.vyMetersPerSecond, speeds.vxMetersPerSecond);
-        Rotation2d targetHeading = new Rotation2d(targetHeadingRadians);
-        double omega = snapToAngle(targetHeading);
+        if (alignedHeading) {
+            double targetHeadingRadians =
+                    Math.atan2(speeds.vyMetersPerSecond, speeds.vxMetersPerSecond);
+            Rotation2d targetHeading = new Rotation2d(targetHeadingRadians);
+            double omega = snapToAngle(targetHeading);
 
-        swerve.setControl(fieldCentric.withVelocityX(speeds.vxMetersPerSecond)
-                .withVelocityY(speeds.vyMetersPerSecond)
-                .withRotationalRate(omega));
+            swerve.setControl(fieldCentric.withVelocityX(speeds.vxMetersPerSecond)
+                    .withVelocityY(speeds.vyMetersPerSecond).withRotationalRate(omega));
+        } else {
+            swerve.setControl(fieldCentric.withVelocityX(speeds.vxMetersPerSecond)
+                    .withVelocityY(speeds.vyMetersPerSecond)
+                    .withRotationalRate(speeds.omegaRadiansPerSecond));
+        }
+
     }
 
     /**
@@ -193,6 +201,10 @@ public class Swerve extends SubsystemBase {
      */
     public void resetHeading() {
         swerve.seedFieldCentric();
+    }
+
+    public void alignedHeading() {
+        alignedHeading = !alignedHeading;
     }
 
     /**

--- a/robot-production/src/main/java/frc/robot/subsystems/swerve/Swerve.java
+++ b/robot-production/src/main/java/frc/robot/subsystems/swerve/Swerve.java
@@ -169,14 +169,14 @@ public class Swerve extends SubsystemBase {
     public void drive(ChassisSpeeds speeds) {
         Logger.recordOutput(SWERVE.LOG_PATH + "TargetSpeeds", speeds);
 
-        if (alignedHeading) {
-            double targetHeadingRadians =
-                    Math.atan2(speeds.vyMetersPerSecond, speeds.vxMetersPerSecond);
+        if (alignedHeading && speeds != null && !speeds.equals(speedZero)) {
+            double targetHeadingRadians = Math.atan2(speeds.vyMetersPerSecond, speeds.vxMetersPerSecond);
             Rotation2d targetHeading = new Rotation2d(targetHeadingRadians);
             double omega = snapToAngle(targetHeading);
 
             swerve.setControl(fieldCentric.withVelocityX(speeds.vxMetersPerSecond)
-                    .withVelocityY(speeds.vyMetersPerSecond).withRotationalRate(omega));
+                    .withVelocityY(speeds.vyMetersPerSecond)
+                    .withRotationalRate(omega));
         } else {
             swerve.setControl(fieldCentric.withVelocityX(speeds.vxMetersPerSecond)
                     .withVelocityY(speeds.vyMetersPerSecond)


### PR DESCRIPTION
adds a method + trigger that allows for a drive mode where the direction that the driver drives, the robot automatically rotates to it. assigned to y on driver controller. pid tuning may be required, but only saw slight jitter, so p term is likely to be a bit too high.